### PR TITLE
fix: rescaled b5 to 10m in BRI

### DIFF
--- a/src/greensenti/band_arithmetic.py
+++ b/src/greensenti/band_arithmetic.py
@@ -353,7 +353,8 @@ def bri(b3: Path, b5: Path, b8: Path, *, output: Path | None = None) -> np.ndarr
     :return: BRI index.
     """
     band_3, kwargs = read(b3)
-    band_5, _ = read(b5)
+    band_5, kwargs_5 = read(b5)
+    band_5, _ = rescale_band(band_5, kwargs_5)
     band_8, _ = read(b8)
 
     bri = (1 / band_3 - 1 / band_5) / band_8


### PR DESCRIPTION
In PR #18, the rescale of band 5 to 10m for the BRI index was accidentally removed.
The rule for computing indices with bands of different resolutions is to pick the lowest resolution in common. However, band 8 is troublesome as it only reports 10m accuracy. Therefore, a rescale of the other bands to 10m is mandatory.